### PR TITLE
Update Dockerfile -- curl syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ RUN set -x && \
     fc-cache -fv && \
     mkdir /drivers_inc && \
     cd /drivers_inc && \
-    curl -JLO https://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar && \
-    curl -JLO https://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/$MARIADB_VERSION/mariadb-java-client-$MARIADB_VERSION.jar && \
-    curl -JLO https://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/$POSTGRESQL_VERSION/postgresql-$POSTGRESQL_VERSION.jar && \
-    curl -JLO https://search.maven.org/remotecontent?filepath=net/sourceforge/jtds/jtds/$JTDS_VERSION/jtds-$JTDS_VERSION.jar && \
+    curl -JL https://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar --output mysql-connector-java-$MYSQL_VERSION.jar && \
+    curl -JL https://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/$MARIADB_VERSION/mariadb-java-client-$MARIADB_VERSION.jar --output mariadb-java-client-$MARIADB_VERSION.jar && \
+    curl -JL https://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/$POSTGRESQL_VERSION/postgresql-$POSTGRESQL_VERSION.jar --output postgresql-$POSTGRESQL_VERSION.jar && \
+    curl -JL https://search.maven.org/remotecontent?filepath=net/sourceforge/jtds/jtds/$JTDS_VERSION/jtds-$JTDS_VERSION.jar --output jtds-$JTDS_VERSION.jar && \
     apk del curl
 
 ADD target/schema*.jar /usr/local/lib/schemaspy/


### PR DESCRIPTION
Hi!

I updated the curl syntax for the driver downloads, providing directly the output filename which apparently does not get parsed correctly by the -O option with recent versions of curl. I get the same driver issue as in your own automatic PR, only since a few days ago, it was running fine before.

I did not run the tests but running curl manually shows the error, the parsed filename is only `remotecontent` and therefore the previous downloads get overwritten as the name is always the same. Change happened between curl versions 7.84.0 and 7.86.0.